### PR TITLE
ci(release-drafter): ejecutar solo en push a main y manual

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,16 +3,7 @@ name: Release Drafter
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - edited
-      - labeled
-      - unlabeled
-      - closed
-  workflow_dispatch: {}   # permite disparo manual desde la UI
+  workflow_dispatch: {}   # ejecución manual opcional
 
 permissions:
   contents: write


### PR DESCRIPTION
- Quita disparador en pull_request para evitar fallas de check en PRs
- Mantiene push a main y workflow_dispatch