### PR TITLE
ci(labeler): usar actions/labeler@v5 y habilitar sync-labels

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,13 +1,19 @@
 name: Pull Request Labeler
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-  workflow_dispatch: {}
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+  workflow_dispatch: {}   # opcional: ejecutar manualmente
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: write   # requerido para aplicar labels
 
 concurrency:
   group: pr-labeler-${{ github.event.pull_request.number || github.ref }}
@@ -16,7 +22,8 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # No correr en borradores, salvo cuando pasan a ready_for_review
+    if: github.event_name != 'pull_request_target' || (github.event.pull_request.draft == false || github.event.action == 'ready_for_review')
     steps:
       - name: Apply labels based on paths
         uses: actions/labeler@v5


### PR DESCRIPTION
Corrige el workflow del labeler (pull_request_target + condición para drafts) y apunta a .github/labeler.yml.