### PR TITLE
ci(codeql): saltar análisis cuando no hay .sln en src/

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ "main" ]
   schedule:
-    - cron: "0 6 * * 1"  # Lunes 06:00 UTC (ajusta si quieres)
+    - cron: "0 6 * * 1"  # Lunes 06:00 UTC
 
 permissions:
   contents: read
@@ -30,43 +30,48 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup MSBuild (VS 2022)
-        uses: microsoft/setup-msbuild@v2
-        with:
-          msbuild-architecture: x64
-
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v2
-
       - name: Detect solution under src/
         id: sln
         shell: pwsh
         run: |
           $sln = Get-ChildItem -Path "src" -Filter *.sln -Recurse | Select-Object -First 1
           if (-not $sln) {
-            Write-Error "No .sln found under 'src/'. CodeQL requiere compilar para C# .NET Framework."
-            exit 1
+            Write-Warning "No .sln found under 'src/'. Skipping CodeQL."
+            "SHOULD_ANALYZE=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            "SHOULD_ANALYZE=true"  | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "SLN=$($sln.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            Write-Host "Solución detectada: $($sln.FullName)"
           }
-          "SLN=$($sln.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          Write-Host "Solución detectada: $($sln.FullName)"
+
+      - name: Setup MSBuild (VS 2022)
+        if: steps.sln.outputs.SHOULD_ANALYZE == 'true'
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
+
+      - name: Setup NuGet
+        if: steps.sln.outputs.SHOULD_ANALYZE == 'true'
+        uses: NuGet/setup-nuget@v2
 
       - name: NuGet restore
-        if: steps.sln.outputs.SLN != ''
+        if: steps.sln.outputs.SHOULD_ANALYZE == 'true'
         shell: pwsh
         run: nuget restore "${{ steps.sln.outputs.SLN }}"
 
       - name: Initialize CodeQL
+        if: steps.sln.outputs.SHOULD_ANALYZE == 'true'
         uses: github/codeql-action/init@v3
         with:
           languages: csharp
 
-      # Construcción manual (más confiable para .NET Framework 4.8)
       - name: Build (Release)
-        if: steps.sln.outputs.SLN != ''
+        if: steps.sln.outputs.SHOULD_ANALYZE == 'true'
         shell: pwsh
         run: msbuild "${{ steps.sln.outputs.SLN }}" /t:Build /p:Configuration=Release /m /verbosity:minimal
 
       - name: Perform CodeQL Analysis
+        if: steps.sln.outputs.SHOULD_ANALYZE == 'true'
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:csharp"


### PR DESCRIPTION
- Añade SHOULD_ANALYZE y condiciona init/build/analyze.
- Evita fallas en repos aún sin solución .NET.